### PR TITLE
Восстановить вывод локализованных текстов задач

### DIFF
--- a/app.js
+++ b/app.js
@@ -140,44 +140,11 @@ async function loadRandomTask() {
 
 // Вспомогательная функция для получения файла текущей задачи
 function getCurrentTaskFile() {
-    if (!currentTask) return null;
+    if (!currentTask || !currentTask.id) return null;
     
-    // Ищем файл текущей задачи в списке всех задач
-    for (const task of allTasks) {
-        if (task.id === currentTask.id) {
-            return task.file;
-        }
-        
-        // Проверяем совпадение по заголовку с учетом локализации
-        if (currentTask.title && task.title) {
-            // Если оба заголовка - строки
-            if (typeof currentTask.title === 'string' && typeof task.title === 'string') {
-                if (task.title === currentTask.title) {
-                    return task.file;
-                }
-            }
-            // Если оба заголовка - объекты с локализацией
-            else if (typeof currentTask.title === 'object' && typeof task.title === 'object') {
-                if ((currentTask.title.en && task.title.en && currentTask.title.en === task.title.en) ||
-                    (currentTask.title.ru && task.title.ru && currentTask.title.ru === task.title.ru)) {
-                    return task.file;
-                }
-            }
-            // Смешанный случай - текущая задача объект, задача из списка строка
-            else if (typeof currentTask.title === 'object' && typeof task.title === 'string') {
-                if (currentTask.title.en === task.title || currentTask.title.ru === task.title) {
-                    return task.file;
-                }
-            }
-            // Смешанный случай - текущая задача строка, задача из списка объект
-            else if (typeof currentTask.title === 'string' && typeof task.title === 'object') {
-                if (task.title.en === currentTask.title || task.title.ru === currentTask.title) {
-                    return task.file;
-                }
-            }
-        }
-    }
-    return null;
+    // Ищем файл текущей задачи в списке всех задач по ID
+    const task = allTasks.find(task => task.id === currentTask.id);
+    return task ? task.file : null;
 }
 
 // Загрузка конкретной задачи / Loading specific task

--- a/app.js
+++ b/app.js
@@ -144,12 +144,37 @@ function getCurrentTaskFile() {
     
     // Ищем файл текущей задачи в списке всех задач
     for (const task of allTasks) {
-        if (task.id === currentTask.id || 
-            (currentTask.title && 
-             ((typeof currentTask.title === 'string' && task.title === currentTask.title) ||
-              (typeof currentTask.title === 'object' && 
-               (task.title === currentTask.title.en || task.title === currentTask.title.ru))))) {
+        if (task.id === currentTask.id) {
             return task.file;
+        }
+        
+        // Проверяем совпадение по заголовку с учетом локализации
+        if (currentTask.title && task.title) {
+            // Если оба заголовка - строки
+            if (typeof currentTask.title === 'string' && typeof task.title === 'string') {
+                if (task.title === currentTask.title) {
+                    return task.file;
+                }
+            }
+            // Если оба заголовка - объекты с локализацией
+            else if (typeof currentTask.title === 'object' && typeof task.title === 'object') {
+                if ((currentTask.title.en && task.title.en && currentTask.title.en === task.title.en) ||
+                    (currentTask.title.ru && task.title.ru && currentTask.title.ru === task.title.ru)) {
+                    return task.file;
+                }
+            }
+            // Смешанный случай - текущая задача объект, задача из списка строка
+            else if (typeof currentTask.title === 'object' && typeof task.title === 'string') {
+                if (currentTask.title.en === task.title || currentTask.title.ru === task.title) {
+                    return task.file;
+                }
+            }
+            // Смешанный случай - текущая задача строка, задача из списка объект
+            else if (typeof currentTask.title === 'string' && typeof task.title === 'object') {
+                if (task.title.en === currentTask.title || task.title.ru === currentTask.title) {
+                    return task.file;
+                }
+            }
         }
     }
     return null;
@@ -191,7 +216,10 @@ function initTaskDatabase() {
         
 
         
-        console.log('База данных инициализирована для задачи:', currentTask.title);
+        const taskTitle = typeof currentTask.title === 'object' 
+            ? (currentTask.title[i18n.getCurrentLanguage()] || currentTask.title.en || currentTask.title.ru)
+            : currentTask.title;
+        console.log('База данных инициализирована для задачи:', taskTitle);
     } catch (error) {
         console.error('Ошибка инициализации базы данных для задачи:', error);
     }

--- a/sql-tasks/index.json
+++ b/sql-tasks/index.json
@@ -1,20 +1,38 @@
 [
   {
     "id": "basic_select",
-    "title": "Простая выборка данных",
-    "description": "Выберите всех студентов старше 20 лет",
+    "title": {
+      "en": "Basic Data Selection",
+      "ru": "Простая выборка данных"
+    },
+    "description": {
+      "en": "Select all students older than 20 years",
+      "ru": "Выберите всех студентов старше 20 лет"
+    },
     "file": "basic_select.json"
   },
   {
     "id": "join_tables",
-    "title": "Соединение таблиц", 
-    "description": "Найдите всех студентов с их оценками",
+    "title": {
+      "en": "Table Joins",
+      "ru": "Соединение таблиц"
+    },
+    "description": {
+      "en": "Find all students with their Math grades",
+      "ru": "Найдите всех студентов с их оценками по математике"
+    },
     "file": "join_tables.json"
   },
   {
     "id": "aggregation",
-    "title": "Агрегация данных",
-    "description": "Посчитайте количество студентов по возрасту",
+    "title": {
+      "en": "Data Aggregation", 
+      "ru": "Агрегация данных"
+    },
+    "description": {
+      "en": "Count the number of students for each age",
+      "ru": "Посчитайте количество студентов для каждого возраста"
+    },
     "file": "aggregation.json"
   }
 ]

--- a/tests/puppeteer-tests.js
+++ b/tests/puppeteer-tests.js
@@ -406,6 +406,127 @@ class SQLitePlaygroundTests {
         return { taskTitle, taskHeader };
     }
 
+    async testTaskTextFieldsLocalization() {
+        console.log('\n🧪 Тест: Проверка локализации всех текстовых полей задач');
+
+        // Тестируем на русском языке
+        await this.page.select('#language-select', 'ru');
+        await new Promise(resolve => setTimeout(resolve, 500));
+
+        // Проверяем несколько задач подряд
+        for (let attempt = 0; attempt < 3; attempt++) {
+            console.log(`\n📝 Проверка задачи ${attempt + 1}:`);
+            
+            // Ждем загрузки задачи
+            await this.page.waitForSelector('.task-header h3', { timeout: 5000 });
+            
+            // 1. Проверяем заголовок задачи
+            const taskTitle = await this.page.$eval('.task-header h3', el => el.textContent);
+            console.log(`  ✓ Заголовок: "${taskTitle}"`);
+            
+            // Проверяем что заголовок не содержит [object Object]
+            await this.runner.assert(
+                !taskTitle.includes('[object Object]'),
+                `Заголовок задачи не содержит [object Object]: "${taskTitle}"`
+            );
+            
+            // Проверяем что заголовок не пустой
+            await this.runner.assert(
+                taskTitle.trim().length > 0,
+                `Заголовок задачи не пустой: "${taskTitle}"`
+            );
+
+            // 2. Проверяем описание задачи
+            const taskDescription = await this.page.$eval('.task-description p', el => el.textContent);
+            console.log(`  ✓ Описание: "${taskDescription.substring(0, 50)}..."`);
+            
+            // Проверяем что описание не содержит [object Object]
+            await this.runner.assert(
+                !taskDescription.includes('[object Object]'),
+                `Описание задачи не содержит [object Object]: "${taskDescription}"`
+            );
+            
+            // Проверяем что описание не пустое
+            await this.runner.assert(
+                taskDescription.trim().length > 0,
+                `Описание задачи не пустое: "${taskDescription}"`
+            );
+
+            // 3. Проверяем подсказку (показываем её сначала)
+            const hintButton = await this.page.$('.btn-hint');
+            await hintButton.click();
+            await this.page.waitForSelector('.task-hint', { visible: true });
+            
+            const hintText = await this.page.$eval('.task-hint p', el => el.textContent);
+            console.log(`  ✓ Подсказка: "${hintText.substring(0, 50)}..."`);
+            
+            // Проверяем что подсказка не содержит [object Object]
+            await this.runner.assert(
+                !hintText.includes('[object Object]'),
+                `Подсказка не содержит [object Object]: "${hintText}"`
+            );
+            
+            // Проверяем что подсказка содержит текст (не только лейбл)
+            const hintLabel = await this.page.evaluate(() => window.i18n.t('task.hint_label'));
+            const hintContent = hintText.replace(hintLabel, '').trim();
+            await this.runner.assert(
+                hintContent.length > 0,
+                `Подсказка содержит текст помимо лейбла: "${hintContent}"`
+            );
+
+            // Скрываем подсказку обратно
+            await hintButton.click();
+
+            // 4. Проверяем что все тексты на русском языке (содержат кириллицу)
+            const hasRussianInTitle = /[а-яё]/i.test(taskTitle);
+            const hasRussianInDescription = /[а-яё]/i.test(taskDescription);
+            const hasRussianInHint = /[а-яё]/i.test(hintContent);
+            
+            await this.runner.assert(
+                hasRussianInTitle || hasRussianInDescription || hasRussianInHint,
+                'По крайней мере одно поле содержит русский текст'
+            );
+
+            // Переходим к следующей задаче
+            if (attempt < 2) {
+                const nextButton = await this.page.$('button[onclick="loadRandomTask()"]');
+                await nextButton.click();
+                await new Promise(resolve => setTimeout(resolve, 1000));
+            }
+        }
+
+        // Тестируем на английском языке
+        console.log('\n🌍 Переключение на английский язык:');
+        await this.page.select('#language-select', 'en');
+        await new Promise(resolve => setTimeout(resolve, 500));
+
+        // Проверяем одну задачу на английском
+        await this.page.waitForSelector('.task-header h3', { timeout: 5000 });
+        
+        const englishTitle = await this.page.$eval('.task-header h3', el => el.textContent);
+        const englishDescription = await this.page.$eval('.task-description p', el => el.textContent);
+        
+        console.log(`  ✓ English title: "${englishTitle}"`);
+        console.log(`  ✓ English description: "${englishDescription.substring(0, 50)}..."`);
+        
+        // Проверяем что тексты на английском (содержат латиницу)
+        const hasEnglishInTitle = /[a-z]/i.test(englishTitle);
+        const hasEnglishInDescription = /[a-z]/i.test(englishDescription);
+        
+        await this.runner.assert(
+            hasEnglishInTitle && hasEnglishInDescription,
+            'Заголовок и описание содержат английский текст'
+        );
+
+        // Проверяем что нет [object Object] на английском
+        await this.runner.assert(
+            !englishTitle.includes('[object Object]') && !englishDescription.includes('[object Object]'),
+            'Английские тексты не содержат [object Object]'
+        );
+
+        console.log('✅ Все текстовые поля задач корректно локализованы!');
+    }
+
     async testTaskExecution(taskTitle) {
         console.log('\n🧪 Тест: Выполнение SQL задачи');
         
@@ -656,6 +777,7 @@ async function runTests() {
         await tests.testResponsiveDesign();
         
         const { taskTitle } = await tests.testTaskSystem();
+        await tests.testTaskTextFieldsLocalization();
         await tests.testTaskExecution(taskTitle);
         await tests.testSchemaUpdateAfterInsert();
         await tests.testTaskSwitch(taskTitle);


### PR DESCRIPTION
Refactor task display logic to correctly show localized task titles and descriptions, and simplify task lookup by using only task IDs.

The initial problem was `[object Object]` appearing in the UI because `sql-tasks/index.json` contained string values for `title` and `description`, while individual task files used localized objects. This PR updates `index.json` to match the localized object structure. Additionally, the `getCurrentTaskFile()` function's complex logic for finding tasks by title was simplified to rely solely on unique task IDs, which are now consistently available and sufficient. This improves code clarity, reliability, and performance.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-66ccbc20-3b9d-454d-9bf8-b6d60a0cd22d) · [Cursor](https://cursor.com/background-agent?bcId=bc-66ccbc20-3b9d-454d-9bf8-b6d60a0cd22d)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)